### PR TITLE
As of Magnolia 6, the label / description is hidden inside composite …

### DIFF
--- a/src/main/java/com/namics/oss/magnolia/dictionary/field/MultiTextFieldDefinition.java
+++ b/src/main/java/com/namics/oss/magnolia/dictionary/field/MultiTextFieldDefinition.java
@@ -41,6 +41,7 @@ public class MultiTextFieldDefinition extends TextFieldDefinition {
 			textField.setValidators(this.getValidators());
 			textField.setName(LocaleUtils.getLocaleString(locale));
 			textField.setLabel(locale.getDisplayName());
+			textField.setPlaceholder(locale.getDisplayName());
 			fields.add(textField);
 		}
 


### PR DESCRIPTION
…fields

- add placeholder property to textfield with the value of the language if a field is not translated